### PR TITLE
Add id back to declared resource properties

### DIFF
--- a/lib/templates/resource.ejs
+++ b/lib/templates/resource.ejs
@@ -198,6 +198,7 @@ module Asana
 <% _.forEach(mixinsToInclude, function(mixin) { %>
       include <%= mixin %>
 <% }) %>
+      attr_reader :id
 <% _.forEach(resource.properties, function(property) { %>
       attr_reader :<%= property.name %>
 <% }) %>


### PR DESCRIPTION
Not adding it to `Resource` class itself because not all subclasses have IDs (e.g. `Event`).