### PR TITLE
The faraday configuration is not being send properly to Asana::HttpClient when instantiating a Asana::Client

### DIFF
--- a/lib/asana/client.rb
+++ b/lib/asana/client.rb
@@ -79,7 +79,7 @@ module Asana
                        adapter:        config[:faraday_adapter],
                        user_agent:     config[:user_agent],
                        debug_mode:     config[:debug_mode],
-                       &config[:faraday_config])
+                       &config[:faraday_configuration])
     end
 
     # Public: Performs a GET request against an arbitrary Asana URL. Allows for


### PR DESCRIPTION
This happened because in the Asana::Client::Configuration you have this line:

```ruby
def configure_faraday(&config)
        @configuration[:faraday_configuration] = config
end
```

However the intialize method of Asana::Client was using this code:

```ruby
 HttpClient.new(authentication: config.fetch(:authentication),
                       adapter:        config[:faraday_adapter],
                       user_agent:     config[:user_agent],
                       debug_mode:     config[:debug_mode],
                       &config[:faraday_config])
```


As you can see, the last line in that method should have been **&config[:faraday_configuration]**

I discovered this when i tried using em_http adapter with Faraday::Adapter::EMHttp , i noticed that it was not instantiating the correct http client. 

This pull request is for fixing this issue.   


