### PR TITLE
Pin Rubocop version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,13 @@ source 'https://rubygems.org'
 gemspec
 
 group :tools do
-  gem 'rubocop'
-  gem 'rubocop-rspec'
+  # Currently we need to pin the version of Rubocop, due to an incompatibility
+  # with rubocop-rspec.  However, this also solves the problem that Rubocop
+  # routinely adds new checks which can cause our build to "break" even when no
+  # changes have been made. In this situation it's better to intentionally
+  # upgrade Rubocop and fix issues at that time.
+  gem 'rubocop', '~> 0.35.0'
+  gem 'rubocop-rspec', '~> 1.2.0'
 
   gem 'guard'
   gem 'guard-rspec'


### PR DESCRIPTION
This solved the issue that changes to rubocop or rubocop-rspec would break our build even when no code changed. This means pull requests would often appear to fail, when the only issue was new rubocop rules that existing code failed, which is a terrible contributor experience.

Instead, we will intentionally upgrade those libraries going forward.