### PR TITLE
Fix #45 - Rename global method to a library-specific name, to avoid interfering with other libraries

### DIFF
--- a/lib/asana/authentication/oauth2.rb
+++ b/lib/asana/authentication/oauth2.rb
@@ -26,8 +26,8 @@ module Asana
       #
       # Note: This function reads from STDIN and writes to STDOUT. It is meant
       # to be used only within the context of a CLI application.
-      def offline_flow(client_id: required('client_id'),
-                       client_secret: required('client_secret'))
+      def offline_flow(client_id: asana_arg_required('client_id'),
+                       client_secret: asana_arg_required('client_secret'))
         client = Client.new(client_id: client_id,
                             client_secret: client_secret,
                             redirect_uri: 'urn:ietf:wg:oauth:2.0:oob')

--- a/lib/asana/authentication/oauth2/access_token_authentication.rb
+++ b/lib/asana/authentication/oauth2/access_token_authentication.rb
@@ -18,9 +18,9 @@ module Asana
         # Returns an [AccessTokenAuthentication] instance with a refreshed
         # access token.
         def self.from_refresh_token(refresh_token,
-                                    client_id: required('client_id'),
-                                    client_secret: required('client_secret'),
-                                    redirect_uri: required('redirect_uri'))
+                                    client_id: asana_arg_required('client_id'),
+                                    client_secret: asana_arg_required('client_secret'),
+                                    redirect_uri: asana_arg_required('redirect_uri'))
           client = Client.new(client_id: client_id,
                               client_secret: client_secret,
                               redirect_uri: redirect_uri)

--- a/lib/asana/authentication/oauth2/client.rb
+++ b/lib/asana/authentication/oauth2/client.rb
@@ -15,9 +15,9 @@ module Asana
         #                 application
         # redirect_uri  - [String] a redirect uri from the registered
         #                 application
-        def initialize(client_id: required('client_id'),
-                       client_secret: required('client_secret'),
-                       redirect_uri: required('redirect_uri'))
+        def initialize(client_id: asana_arg_required('client_id'),
+                       client_secret: asana_arg_required('client_secret'),
+                       redirect_uri: asana_arg_required('redirect_uri'))
           @client = ::OAuth2::Client.new(client_id, client_secret,
                                          site: 'https://app.asana.com',
                                          authorize_url: '/-/oauth_authorize',

--- a/lib/asana/client.rb
+++ b/lib/asana/client.rb
@@ -54,7 +54,7 @@ module Asana
     # Internal: Proxies Resource classes to implement a fluent API on the Client
     # instances.
     class ResourceProxy
-      def initialize(client: required('client'), resource: required('resource'))
+      def initialize(client: asana_arg_required('client'), resource: asana_arg_required('resource'))
         @client   = client
         @resource = resource
       end

--- a/lib/asana/http_client.rb
+++ b/lib/asana/http_client.rb
@@ -22,7 +22,7 @@ module Asana
     # user_agent     - [String] The user agent. Defaults to "ruby-asana vX.Y.Z".
     # config         - [Proc] An optional block that yields the Faraday builder
     #                  object for customization.
-    def initialize(authentication: required('authentication'),
+    def initialize(authentication: asana_arg_required('authentication'),
                    adapter: nil,
                    user_agent: nil,
                    debug_mode: false,

--- a/lib/asana/resource_includes/attachment_uploading.rb
+++ b/lib/asana/resource_includes/attachment_uploading.rb
@@ -12,8 +12,8 @@ module Asana
       #
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/MethodLength
-      def attach(filename: required('filename'),
-                 mime: required('mime'),
+      def attach(filename: asana_arg_required('filename'),
+                 mime: asana_arg_required('mime'),
                  options: {}, **data)
         path = File.expand_path(filename)
         unless File.exist?(path)

--- a/lib/asana/resource_includes/collection.rb
+++ b/lib/asana/resource_includes/collection.rb
@@ -19,7 +19,7 @@ module Asana
       # client            - [Asana::Client] the client to perform requests.
       def initialize((elements, extra),
                      type: Resource,
-                     client: required('client'))
+                     client: asana_arg_required('client'))
         @elements       = elements.map { |elem| type.new(elem, client: client) }
         @type           = type
         @next_page_data = extra['next_page']

--- a/lib/asana/resource_includes/events.rb
+++ b/lib/asana/resource_includes/events.rb
@@ -32,8 +32,8 @@ module Asana
       # client   - [Asana::Client] a client to perform the requests.
       # wait     - [Integer] the number of seconds to wait between each poll.
       # options  - [Hash] the request I/O options
-      def initialize(resource: required('resource'),
-                     client: required('client'),
+      def initialize(resource: asana_arg_required('resource'),
+                     client: asana_arg_required('client'),
                      wait: 1, options: {})
         @resource  = resource
         @client    = client

--- a/lib/asana/resource_includes/resource.rb
+++ b/lib/asana/resource_includes/resource.rb
@@ -13,7 +13,7 @@ module Asana
         Registry.register(base)
       end
 
-      def initialize(data, client: required('client'))
+      def initialize(data, client: asana_arg_required('client'))
         @_client = client
         @_data   = data
         data.each do |k, v|

--- a/lib/asana/resources/attachment.rb
+++ b/lib/asana/resources/attachment.rb
@@ -45,7 +45,7 @@ module Asana
         #
         # per_page - [Integer] the number of records to fetch per page.
         # options - [Hash] the request I/O options.
-        def find_by_task(client, task: required("task"), per_page: 20, options: {})
+        def find_by_task(client, task: asana_arg_required("task"), per_page: 20, options: {})
           params = { limit: per_page }.reject { |_,v| v.nil? || Array(v).empty? }
           Collection.new(parse(client.get("/tasks/#{task}/attachments", params: params, options: options)), type: self, client: client)
         end

--- a/lib/asana/resources/project.rb
+++ b/lib/asana/resources/project.rb
@@ -70,7 +70,7 @@ module Asana
         #
         # options - [Hash] the request I/O options.
         # data - [Hash] the attributes to post.
-        def create(client, workspace: required("workspace"), team: nil, options: {}, **data)
+        def create(client, workspace: asana_arg_required("workspace"), team: nil, options: {}, **data)
           with_params = data.merge(workspace: workspace, team: team).reject { |_,v| v.nil? || Array(v).empty? }
           self.new(parse(client.post("/projects", body: with_params, options: options)).first, client: client)
         end
@@ -83,7 +83,7 @@ module Asana
         # workspace - [Id] The workspace or organization to create the project in.
         # options - [Hash] the request I/O options.
         # data - [Hash] the attributes to post.
-        def create_in_workspace(client, workspace: required("workspace"), options: {}, **data)
+        def create_in_workspace(client, workspace: asana_arg_required("workspace"), options: {}, **data)
 
           self.new(parse(client.post("/workspaces/#{workspace}/projects", body: data, options: options)).first, client: client)
         end
@@ -95,7 +95,7 @@ module Asana
         # team - [Id] The team to create the project in.
         # options - [Hash] the request I/O options.
         # data - [Hash] the attributes to post.
-        def create_in_team(client, team: required("team"), options: {}, **data)
+        def create_in_team(client, team: asana_arg_required("team"), options: {}, **data)
 
           self.new(parse(client.post("/teams/#{team}/projects", body: data, options: options)).first, client: client)
         end
@@ -132,7 +132,7 @@ module Asana
         #
         # per_page - [Integer] the number of records to fetch per page.
         # options - [Hash] the request I/O options.
-        def find_by_workspace(client, workspace: required("workspace"), archived: nil, per_page: 20, options: {})
+        def find_by_workspace(client, workspace: asana_arg_required("workspace"), archived: nil, per_page: 20, options: {})
           params = { archived: archived, limit: per_page }.reject { |_,v| v.nil? || Array(v).empty? }
           Collection.new(parse(client.get("/workspaces/#{workspace}/projects", params: params, options: options)), type: self, client: client)
         end
@@ -145,7 +145,7 @@ module Asana
         #
         # per_page - [Integer] the number of records to fetch per page.
         # options - [Hash] the request I/O options.
-        def find_by_team(client, team: required("team"), archived: nil, per_page: 20, options: {})
+        def find_by_team(client, team: asana_arg_required("team"), archived: nil, per_page: 20, options: {})
           params = { archived: archived, limit: per_page }.reject { |_,v| v.nil? || Array(v).empty? }
           Collection.new(parse(client.get("/teams/#{team}/projects", params: params, options: options)), type: self, client: client)
         end
@@ -203,7 +203,7 @@ module Asana
       # followers - [Array] An array of followers to add to the project.
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def add_followers(followers: required("followers"), options: {}, **data)
+      def add_followers(followers: asana_arg_required("followers"), options: {}, **data)
         with_params = data.merge(followers: followers).reject { |_,v| v.nil? || Array(v).empty? }
         refresh_with(parse(client.post("/projects/#{id}/addFollowers", body: with_params, options: options)).first)
       end
@@ -214,7 +214,7 @@ module Asana
       # followers - [Array] An array of followers to remove from the project.
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def remove_followers(followers: required("followers"), options: {}, **data)
+      def remove_followers(followers: asana_arg_required("followers"), options: {}, **data)
         with_params = data.merge(followers: followers).reject { |_,v| v.nil? || Array(v).empty? }
         refresh_with(parse(client.post("/projects/#{id}/removeFollowers", body: with_params, options: options)).first)
       end
@@ -224,7 +224,7 @@ module Asana
       # members - [Array] An array of members to add to the project.
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def add_members(members: required("members"), options: {}, **data)
+      def add_members(members: asana_arg_required("members"), options: {}, **data)
         with_params = data.merge(members: members).reject { |_,v| v.nil? || Array(v).empty? }
         refresh_with(parse(client.post("/projects/#{id}/addMembers", body: with_params, options: options)).first)
       end

--- a/lib/asana/resources/story.rb
+++ b/lib/asana/resources/story.rb
@@ -47,7 +47,7 @@ module Asana
         #
         # per_page - [Integer] the number of records to fetch per page.
         # options - [Hash] the request I/O options.
-        def find_by_task(client, task: required("task"), per_page: 20, options: {})
+        def find_by_task(client, task: asana_arg_required("task"), per_page: 20, options: {})
           params = { limit: per_page }.reject { |_,v| v.nil? || Array(v).empty? }
           Collection.new(parse(client.get("/tasks/#{task}/stories", params: params, options: options)), type: self, client: client)
         end
@@ -73,7 +73,7 @@ module Asana
         # text - [String] The plain text of the comment to add.
         # options - [Hash] the request I/O options.
         # data - [Hash] the attributes to post.
-        def create_on_task(client, task: required("task"), text: required("text"), options: {}, **data)
+        def create_on_task(client, task: asana_arg_required("task"), text: asana_arg_required("text"), options: {}, **data)
           with_params = data.merge(text: text).reject { |_,v| v.nil? || Array(v).empty? }
           self.new(parse(client.post("/tasks/#{task}/stories", body: with_params, options: options)).first, client: client)
         end

--- a/lib/asana/resources/tag.rb
+++ b/lib/asana/resources/tag.rb
@@ -45,7 +45,7 @@ module Asana
         # workspace - [Id] The workspace or organization to create the tag in.
         # options - [Hash] the request I/O options.
         # data - [Hash] the attributes to post.
-        def create(client, workspace: required("workspace"), options: {}, **data)
+        def create(client, workspace: asana_arg_required("workspace"), options: {}, **data)
           with_params = data.merge(workspace: workspace).reject { |_,v| v.nil? || Array(v).empty? }
           self.new(parse(client.post("/tags", body: with_params, options: options)).first, client: client)
         end
@@ -62,7 +62,7 @@ module Asana
         # workspace - [Id] The workspace or organization to create the tag in.
         # options - [Hash] the request I/O options.
         # data - [Hash] the attributes to post.
-        def create_in_workspace(client, workspace: required("workspace"), options: {}, **data)
+        def create_in_workspace(client, workspace: asana_arg_required("workspace"), options: {}, **data)
 
           self.new(parse(client.post("/workspaces/#{workspace}/tags", body: data, options: options)).first, client: client)
         end
@@ -96,7 +96,7 @@ module Asana
         # workspace - [Id] The workspace or organization to find tags in.
         # per_page - [Integer] the number of records to fetch per page.
         # options - [Hash] the request I/O options.
-        def find_by_workspace(client, workspace: required("workspace"), per_page: 20, options: {})
+        def find_by_workspace(client, workspace: asana_arg_required("workspace"), per_page: 20, options: {})
           params = { limit: per_page }.reject { |_,v| v.nil? || Array(v).empty? }
           Collection.new(parse(client.get("/workspaces/#{workspace}/tags", params: params, options: options)), type: self, client: client)
         end

--- a/lib/asana/resources/task.rb
+++ b/lib/asana/resources/task.rb
@@ -89,7 +89,7 @@ module Asana
         # workspace - [Id] The workspace to create a task in.
         # options - [Hash] the request I/O options.
         # data - [Hash] the attributes to post.
-        def create_in_workspace(client, workspace: required("workspace"), options: {}, **data)
+        def create_in_workspace(client, workspace: asana_arg_required("workspace"), options: {}, **data)
 
           self.new(parse(client.post("/workspaces/#{workspace}/tasks", body: data, options: options)).first, client: client)
         end
@@ -109,7 +109,7 @@ module Asana
         # projectId - [Id] The project in which to search for tasks.
         # per_page - [Integer] the number of records to fetch per page.
         # options - [Hash] the request I/O options.
-        def find_by_project(client, projectId: required("projectId"), per_page: 20, options: {})
+        def find_by_project(client, projectId: asana_arg_required("projectId"), per_page: 20, options: {})
           params = { limit: per_page }.reject { |_,v| v.nil? || Array(v).empty? }
           Collection.new(parse(client.get("/projects/#{projectId}/tasks", params: params, options: options)), type: self, client: client)
         end
@@ -119,7 +119,7 @@ module Asana
         # tag - [Id] The tag in which to search for tasks.
         # per_page - [Integer] the number of records to fetch per page.
         # options - [Hash] the request I/O options.
-        def find_by_tag(client, tag: required("tag"), per_page: 20, options: {})
+        def find_by_tag(client, tag: asana_arg_required("tag"), per_page: 20, options: {})
           params = { limit: per_page }.reject { |_,v| v.nil? || Array(v).empty? }
           Collection.new(parse(client.get("/tags/#{tag}/tasks", params: params, options: options)), type: self, client: client)
         end
@@ -188,7 +188,7 @@ module Asana
       # followers - [Array] An array of followers to add to the task.
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def add_followers(followers: required("followers"), options: {}, **data)
+      def add_followers(followers: asana_arg_required("followers"), options: {}, **data)
         with_params = data.merge(followers: followers).reject { |_,v| v.nil? || Array(v).empty? }
         refresh_with(parse(client.post("/tasks/#{id}/addFollowers", body: with_params, options: options)).first)
       end
@@ -199,7 +199,7 @@ module Asana
       # followers - [Array] An array of followers to remove from the task.
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def remove_followers(followers: required("followers"), options: {}, **data)
+      def remove_followers(followers: asana_arg_required("followers"), options: {}, **data)
         with_params = data.merge(followers: followers).reject { |_,v| v.nil? || Array(v).empty? }
         refresh_with(parse(client.post("/tasks/#{id}/removeFollowers", body: with_params, options: options)).first)
       end
@@ -234,7 +234,7 @@ module Asana
       #
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def add_project(project: required("project"), insertAfter: nil, insertBefore: nil, section: nil, options: {}, **data)
+      def add_project(project: asana_arg_required("project"), insertAfter: nil, insertBefore: nil, section: nil, options: {}, **data)
         with_params = data.merge(project: project, insertAfter: insertAfter, insertBefore: insertBefore, section: section).reject { |_,v| v.nil? || Array(v).empty? }
         client.post("/tasks/#{id}/addProject", body: with_params, options: options) && true
       end
@@ -247,7 +247,7 @@ module Asana
       # project - [Id] The project to remove the task from.
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def remove_project(project: required("project"), options: {}, **data)
+      def remove_project(project: asana_arg_required("project"), options: {}, **data)
         with_params = data.merge(project: project).reject { |_,v| v.nil? || Array(v).empty? }
         client.post("/tasks/#{id}/removeProject", body: with_params, options: options) && true
       end
@@ -266,7 +266,7 @@ module Asana
       # tag - [Id] The tag to add to the task.
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def add_tag(tag: required("tag"), options: {}, **data)
+      def add_tag(tag: asana_arg_required("tag"), options: {}, **data)
         with_params = data.merge(tag: tag).reject { |_,v| v.nil? || Array(v).empty? }
         client.post("/tasks/#{id}/addTag", body: with_params, options: options) && true
       end
@@ -276,7 +276,7 @@ module Asana
       # tag - [Id] The tag to remove from the task.
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def remove_tag(tag: required("tag"), options: {}, **data)
+      def remove_tag(tag: asana_arg_required("tag"), options: {}, **data)
         with_params = data.merge(tag: tag).reject { |_,v| v.nil? || Array(v).empty? }
         client.post("/tasks/#{id}/removeTag", body: with_params, options: options) && true
       end
@@ -306,7 +306,7 @@ module Asana
       # parent - [Id] The new parent of the task, or `null` for no parent.
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def set_parent(parent: required("parent"), options: {}, **data)
+      def set_parent(parent: asana_arg_required("parent"), options: {}, **data)
         with_params = data.merge(parent: parent).reject { |_,v| v.nil? || Array(v).empty? }
         client.post("/tasks/#{id}/setParent", body: with_params, options: options) && true
       end
@@ -329,7 +329,7 @@ module Asana
       # text - [String] The plain text of the comment to add.
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def add_comment(text: required("text"), options: {}, **data)
+      def add_comment(text: asana_arg_required("text"), options: {}, **data)
         with_params = data.merge(text: text).reject { |_,v| v.nil? || Array(v).empty? }
         Story.new(parse(client.post("/tasks/#{id}/stories", body: with_params, options: options)).first, client: client)
       end

--- a/lib/asana/resources/team.rb
+++ b/lib/asana/resources/team.rb
@@ -35,7 +35,7 @@ module Asana
         #
         # per_page - [Integer] the number of records to fetch per page.
         # options - [Hash] the request I/O options.
-        def find_by_organization(client, organization: required("organization"), per_page: 20, options: {})
+        def find_by_organization(client, organization: asana_arg_required("organization"), per_page: 20, options: {})
           params = { limit: per_page }.reject { |_,v| v.nil? || Array(v).empty? }
           Collection.new(parse(client.get("/organizations/#{organization}/teams", params: params, options: options)), type: self, client: client)
         end
@@ -61,7 +61,7 @@ module Asana
       #
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def add_user(user: required("user"), options: {}, **data)
+      def add_user(user: asana_arg_required("user"), options: {}, **data)
         with_params = data.merge(user: user).reject { |_,v| v.nil? || Array(v).empty? }
         User.new(parse(client.post("/teams/#{id}/addUser", body: with_params, options: options)).first, client: client)
       end
@@ -75,7 +75,7 @@ module Asana
       #
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def remove_user(user: required("user"), options: {}, **data)
+      def remove_user(user: asana_arg_required("user"), options: {}, **data)
         with_params = data.merge(user: user).reject { |_,v| v.nil? || Array(v).empty? }
         client.post("/teams/#{id}/removeUser", body: with_params, options: options) && true
       end

--- a/lib/asana/resources/user.rb
+++ b/lib/asana/resources/user.rb
@@ -43,7 +43,7 @@ module Asana
         # to indicate the current user making the request.
         #
         # options - [Hash] the request I/O options.
-        def find_by_id(client, user: required("user"), options: {})
+        def find_by_id(client, user: asana_arg_required("user"), options: {})
           params = { user: user }.reject { |_,v| v.nil? || Array(v).empty? }
           Resource.new(parse(client.get("/users/%s", params: params, options: options)).first, client: client)
         end
@@ -54,7 +54,7 @@ module Asana
         # workspace - [Id] The workspace in which to get users.
         # per_page - [Integer] the number of records to fetch per page.
         # options - [Hash] the request I/O options.
-        def find_by_workspace(client, workspace: required("workspace"), per_page: 20, options: {})
+        def find_by_workspace(client, workspace: asana_arg_required("workspace"), per_page: 20, options: {})
           params = { limit: per_page }.reject { |_,v| v.nil? || Array(v).empty? }
           Collection.new(parse(client.get("/workspaces/#{workspace}/users", params: params, options: options)), type: self, client: client)
         end

--- a/lib/asana/resources/webhook.rb
+++ b/lib/asana/resources/webhook.rb
@@ -96,7 +96,7 @@ module Asana
         #
         # options - [Hash] the request I/O options.
         # data - [Hash] the attributes to post.
-        def create(client, resource: required("resource"), target: required("target"), options: {}, **data)
+        def create(client, resource: asana_arg_required("resource"), target: asana_arg_required("target"), options: {}, **data)
           with_params = data.merge(resource: resource, target: target).reject { |_,v| v.nil? || Array(v).empty? }
           self.new(parse(client.post("/webhooks", body: with_params, options: options)).first, client: client)
         end
@@ -110,7 +110,7 @@ module Asana
         #
         # per_page - [Integer] the number of records to fetch per page.
         # options - [Hash] the request I/O options.
-        def get_all(client, workspace: required("workspace"), resource: nil, per_page: 20, options: {})
+        def get_all(client, workspace: asana_arg_required("workspace"), resource: nil, per_page: 20, options: {})
           params = { workspace: workspace, resource: resource, limit: per_page }.reject { |_,v| v.nil? || Array(v).empty? }
           Collection.new(parse(client.get("/webhooks", params: params, options: options)), type: self, client: client)
         end

--- a/lib/asana/resources/workspace.rb
+++ b/lib/asana/resources/workspace.rb
@@ -87,7 +87,7 @@ module Asana
       #
       # per_page - [Integer] the number of records to fetch per page.
       # options - [Hash] the request I/O options.
-      def typeahead(type: required("type"), query: nil, count: nil, per_page: 20, options: {})
+      def typeahead(type: asana_arg_required("type"), query: nil, count: nil, per_page: 20, options: {})
         params = { type: type, query: query, count: count, limit: per_page }.reject { |_,v| v.nil? || Array(v).empty? }
         Collection.new(parse(client.get("/workspaces/#{id}/typeahead", params: params, options: options)), type: Resource, client: client)
       end
@@ -101,7 +101,7 @@ module Asana
       #
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def add_user(user: required("user"), options: {}, **data)
+      def add_user(user: asana_arg_required("user"), options: {}, **data)
         with_params = data.merge(user: user).reject { |_,v| v.nil? || Array(v).empty? }
         User.new(parse(client.post("/workspaces/#{id}/addUser", body: with_params, options: options)).first, client: client)
       end
@@ -115,7 +115,7 @@ module Asana
       #
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def remove_user(user: required("user"), options: {}, **data)
+      def remove_user(user: asana_arg_required("user"), options: {}, **data)
         with_params = data.merge(user: user).reject { |_,v| v.nil? || Array(v).empty? }
         client.post("/workspaces/#{id}/removeUser", body: with_params, options: options) && true
       end

--- a/lib/asana/ruby2_0_0_compatibility.rb
+++ b/lib/asana/ruby2_0_0_compatibility.rb
@@ -1,3 +1,3 @@
-def required(name)
+def asana_arg_required(name)
   fail(ArgumentError, "#{name} is a required keyword argument")
 end

--- a/lib/templates/resource.ejs
+++ b/lib/templates/resource.ejs
@@ -113,7 +113,7 @@ function Action(action) {
     if (!this.isInstanceAction) { argumentNames.push("client") }
     if (this.mainIdParam !== undefined && !this.isInstanceAction) { argumentNames.push("id") }
     _.forEach(this.params, function(param) {
-        argumentNames.push(param.name + ":" + (param.required ? " required(\"" + param.name + "\")" : " nil"))
+        argumentNames.push(param.name + ":" + (param.required ? " asana_arg_required(\"" + param.name + "\")" : " nil"))
     })
     if (this.collection) { argumentNames.push("per_page: 20") }
     if (this.method != 'DELETE')  { argumentNames.push("options: {}") }

--- a/spec/templates/unicorn.rb
+++ b/spec/templates/unicorn.rb
@@ -24,7 +24,7 @@ module Asana
         # world - [Id] The world to create the unicorn in.
         # options - [Hash] the request I/O options.
         # data - [Hash] the attributes to post.
-        def create(client, world: required("world"), options: {}, **data)
+        def create(client, world: asana_arg_required("world"), options: {}, **data)
           with_params = data.merge(world: world).reject { |_,v| v.nil? || Array(v).empty? }
           self.new(parse(client.post("/unicorns", body: with_params, options: options)).first, client: client)
         end
@@ -36,7 +36,7 @@ module Asana
         # world - [Id] The world to create the unicorn in.
         # options - [Hash] the request I/O options.
         # data - [Hash] the attributes to post.
-        def create_in_world(client, world: required("world"), options: {}, **data)
+        def create_in_world(client, world: asana_arg_required("world"), options: {}, **data)
 
           self.new(parse(client.post("/worlds/#{world}/unicorns", body: data, options: options)).first, client: client)
         end
@@ -67,7 +67,7 @@ module Asana
         # world - [Id] The world to find unicorns in.
         # per_page - [Integer] the number of records to fetch per page.
         # options - [Hash] the request I/O options.
-        def find_by_world(client, world: required("world"), per_page: 20, options: {})
+        def find_by_world(client, world: asana_arg_required("world"), per_page: 20, options: {})
           params = { limit: per_page }.reject { |_,v| v.nil? || Array(v).empty? }
           Collection.new(parse(client.get("/worlds/#{world}/unicorns", params: params, options: options)), type: self, client: client)
         end
@@ -103,7 +103,7 @@ module Asana
       # paw - [Id] The paw to add.
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def add_paw(paw: required("paw"), options: {}, **data)
+      def add_paw(paw: asana_arg_required("paw"), options: {}, **data)
         with_params = data.merge(paw: paw).reject { |_,v| v.nil? || Array(v).empty? }
         Resource.new(parse(client.post("/unicorns/#{id}/paws", body: with_params, options: options)).first, client: client)
       end
@@ -113,7 +113,7 @@ module Asana
       # friends - [Array.Id] The friend IDs to add.
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def add_friends(friends: required("friends"), options: {}, **data)
+      def add_friends(friends: asana_arg_required("friends"), options: {}, **data)
         with_params = data.merge(friends: friends).reject { |_,v| v.nil? || Array(v).empty? }
         refresh_with(parse(client.post("/unicorns/#{id}/friends", body: with_params, options: options)).first)
       end


### PR DESCRIPTION
Alternatively we could wrap the method in a module, and include it in the relevant places. Chose not to do this, because I was not sure how editable files that start with are:

```
### WARNING: This file is auto-generated by the asana-api-meta repo. Do not
### edit it manually.
```