### PR TITLE
[Bugfix] Bearer Token Authentication was generating wrong header value 

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,0 +1,37 @@
+
+  appraise "faraday-0.9.0" do
+    gem "faraday", "0.9.0"
+  end
+
+  appraise "faraday-0.9.1" do
+    gem "faraday", "0.9.1"
+  end
+
+  appraise "faraday-0.9.2" do
+    gem "faraday", "0.9.2"
+  end
+
+  appraise "faraday-0.10.0" do
+    gem "faraday", "0.10.0"
+  end
+  appraise "faraday-0.10.1" do
+    gem "faraday", "0.10.1"
+  end
+
+  appraise "faraday-0.11.0" do
+    gem "faraday", "0.11.0"
+  end
+
+ # Oauth2 does not yet support 0.12
+
+  # appraise "faraday-0.12.0" do
+  #   gem "faraday", "0.12.0"
+  # end
+  #
+  # appraise "faraday-0.12.0.1" do
+  #   gem "faraday", "0.12.0.1"
+  # end
+  #
+  # appraise "faraday-0.12.1" do
+  #   gem "faraday", "0.12.1"
+  # end

--- a/Rakefile
+++ b/Rakefile
@@ -78,9 +78,9 @@ task :all do |_t|
     if ENV['BUNDLE_GEMFILE'] =~ /gemfiles/
       appraisal_name = ENV['BUNDLE_GEMFILE'].scan(/faraday\_(.*)\.gemfile/).flatten.first
       command_prefix = "appraisal faraday-#{appraisal_name}"
-      exec("#{command_prefix} bundle install && #{command_prefix} bundle exec rspec && bundle exec rake coveralls:push ")
+      exec("#{command_prefix} bundle install && #{command_prefix} bundle exec rspec ")
     else
-      exec(' bundle exec appraisal install && bundle exec rake appraisal spec && bundle exec rake coveralls:push')
+      exec(' bundle exec appraisal install && bundle exec rake appraisal spec')
     end
   else
     exec('bundle exec appraisal install && bundle exec rake appraisal spec')

--- a/Rakefile
+++ b/Rakefile
@@ -78,7 +78,7 @@ task :all do |_t|
     if ENV['BUNDLE_GEMFILE'] =~ /gemfiles/
       appraisal_name = ENV['BUNDLE_GEMFILE'].scan(/faraday\_(.*)\.gemfile/).flatten.first
       command_prefix = "appraisal faraday-#{appraisal_name}"
-      exec("#{command_prefix} bundle install && #{command_prefix} bundle exec rspec ")
+      exec("#{command_prefix} bundle install && #{command_prefix} bundle exec rspec")
     else
       exec(' bundle exec appraisal install && bundle exec rake appraisal spec')
     end

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,6 @@
+require 'bundler/setup'
+require 'bundler/gem_tasks'
+require 'appraisal'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'yard'
@@ -63,4 +66,23 @@ EOS
   end
 end
 
-task default: [:spec, :rubocop, :yard]
+desc 'Default: run the unit tests.'
+task default: [:all, :rubocop, :yard]
+
+
+desc 'Test the plugin under all supported Rails versions.'
+task :all do |_t|
+  if ENV['TRAVIS']
+    # require 'json'
+    # puts JSON.pretty_generate(ENV.to_hash)
+    if ENV['BUNDLE_GEMFILE'] =~ /gemfiles/
+      appraisal_name = ENV['BUNDLE_GEMFILE'].scan(/faraday\_(.*)\.gemfile/).flatten.first
+      command_prefix = "appraisal faraday-#{appraisal_name}"
+      exec("#{command_prefix} bundle install && #{command_prefix} bundle exec rspec && bundle exec rake coveralls:push ")
+    else
+      exec(' bundle exec appraisal install && bundle exec rake appraisal spec && bundle exec rake coveralls:push')
+    end
+  else
+    exec('bundle exec appraisal install && bundle exec rake appraisal spec')
+  end
+end

--- a/asana.gemspec
+++ b/asana.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.2"
+  spec.add_development_dependency 'appraisal', '~> 2.1', '>= 2.1'
 end

--- a/lib/asana/authentication/oauth2/bearer_token_authentication.rb
+++ b/lib/asana/authentication/oauth2/bearer_token_authentication.rb
@@ -24,7 +24,8 @@ module Asana
         #
         # Returns nothing.
         def configure(connection)
-          connection.request :oauth2, @token
+          connection.authorization :Bearer, @token
+          connection.request :oauth2, token_type: 'bearer'
         end
       end
     end

--- a/spec/asana/authentication/oauth2/bearer_token_authentication_spec.rb
+++ b/spec/asana/authentication/oauth2/bearer_token_authentication_spec.rb
@@ -1,12 +1,19 @@
 # rubocop:disable RSpec/FilePath
 RSpec.describe Asana::Authentication::OAuth2::BearerTokenAuthentication do
-  let(:auth) { described_class.new('MYTOKEN') }
-
-  it 'configures Faraday to use OAuth2 authentication with a bearer token' do
-    conn = Faraday.new do |builder|
+  let(:token) { 'MYTOKEN' }
+  let(:auth) { described_class.new(token) }
+  let(:conn) do
+    Faraday.new do |builder|
       auth.configure(builder)
     end
+  end
+
+  it 'configures Faraday to use OAuth2 authentication with a bearer token' do
     expect(conn.builder.handlers.first).to eq(FaradayMiddleware::OAuth2)
+  end
+
+  it 'configures Faraday to use OAuth2 authentication with a bearer token' do
+    expect(conn.headers['Authorization']).to eq("Bearer #{token}")
   end
 end
 # rubocop:enable RSpec/FilePath


### PR DESCRIPTION
Hello, 
  I was trying today to update my gem [asana_exception_notifier](https://github.com/bogdanRada/asana_exception_notifier) which has a dependency to this gem when i discovered that i was getting a warning : 

```
Warning: FaradayMiddleware::OAuth2 initialized with default token_type - token will be added as both a query string parameter and an Authorization header. In the next major release, tokens will be added exclusively as an Authorization header by default. Please visit https://github.com/lostisland/faraday_middleware/wiki for more information.
```

After debugging the calls i was making to Asana API, i discovered that this gem was not configured properly for bearer token authentication, and because of that Faraday was generating a wrong header 

```
Authorization: "Token token=\"some_token_here\""
```
instead of 
```
Authorization: "Bearer some_token_here"
```

This pull requests configures correctly the Faraday configuration in the class Asana::Authentication::OAuth2::BearerTokenAuthentication

Also added tests for checking that the header generated by Faraday is correct, and integrated Appraisal gem also so that we can test backward compatibility. 

Alll tests are passing locally .


Please let me know what you think. If you want i can keep the old way the gem was working and make another class for this and setup a new authorization type in the Configuration class if needed. 

Thank you very much.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/182694763484872/329129463696479)
