### PR TITLE
Fix inserting task at top/bottom of project

### DIFF
--- a/lib/asana/resources/task.rb
+++ b/lib/asana/resources/task.rb
@@ -230,10 +230,11 @@ module Asana
       # Returns an empty data block.
       #
       # project - [Id] The project to add the task to.
-      # insert_after - [Id] A task in the project to insert the task after, or `null` to
+      #
+      # insert_after - [Id] A task in the project to insert the task after, or `nil` to
       # insert at the beginning of the list.
       #
-      # insert_before - [Id] A task in the project to insert the task before, or `null` to
+      # insert_before - [Id] A task in the project to insert the task before, or `nil` to
       # insert at the end of the list.
       #
       # section - [Id] A section in the project to insert the task into. The task will be
@@ -241,8 +242,10 @@ module Asana
       #
       # options - [Hash] the request I/O options.
       # data - [Hash] the attributes to post.
-      def add_project(project: required("project"), insert_after: nil, insert_before: nil, section: nil, options: {}, **data)
-        with_params = data.merge(project: project, insert_after: insert_after, insert_before: insert_before, section: section).reject { |_,v| v.nil? || Array(v).empty? }
+      def add_project(project: required("project"), insert_after: :not_provided, insert_before: :not_provided, section: nil, options: {}, **data)
+        with_params = data.merge(project: project, insert_after: insert_after, insert_before: insert_before, section: section).reject { |_,v| v.nil? || Array(v).empty? || v == :not_provided }
+        with_params[:insert_after] = nil if insert_after.nil?
+        with_params[:insert_before] = nil if insert_before.nil?
         client.post("/tasks/#{id}/addProject", body: with_params, options: options) && true
       end
 


### PR DESCRIPTION
Currently if you try to follow the documentation and provide null (er, nil) to the insert_before or insert_after arguments to Asana::Resources::Task#add_project, they get filtered out before the actual call to the Asana REST API.

It looks like the API's 'send null to specify top/bottom' protocol conflicted with how Asana::Resources::Task#add_project handled keyword arguments.

This PR adds a workaround to distinguish between 'set to nil' and 'not provided' for the `insert_after` and `insert before` keyword args.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/182694763484872/367044661432583)
