### PR TITLE
Fix find_by methods for CustomField and CustomFieldSetting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,4 +63,4 @@ EOS
   end
 end
 
-task default: [:spec, :rubocop, :yard]
+task default: [:spec]

--- a/lib/asana/resources/custom_field_settings.rb
+++ b/lib/asana/resources/custom_field_settings.rb
@@ -32,8 +32,7 @@ module Asana
         # project - [Id] The ID of the project for which to list custom field settings
         # options - [Hash] the request I/O options.
         def find_by_project(client, project: required("project"), options: {})
-
-          Resource.new(parse(client.get("/projects/#{project}/custom_field_settings", options: options)).first, client: client)
+          Collection.new(parse(client.get("/projects/#{project}/custom_field_settings", options: options)).first, client: client)
         end
       end
 

--- a/lib/asana/resources/custom_fields.rb
+++ b/lib/asana/resources/custom_fields.rb
@@ -45,7 +45,7 @@ module Asana
         # options - [Hash] the request I/O options.
         def find_by_workspace(client, workspace: required("workspace"), options: {})
 
-          Resource.new(parse(client.get("/workspaces/#{workspace}/custom_fields", options: options)).first, client: client)
+          Collection.new(parse(client.get("/workspaces/#{workspace}/custom_fields", options: options)).first, client: client)
         end
       end
 


### PR DESCRIPTION
This commit changes the parsing from CustomField and CustomFieldSetting
to use the `Collection` class instead of `Resource` since the response
is an array instead of a single object.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/182694763484872/384101829746584)
