### PR TITLE
Add gid attribute reader to User resource

### DIFF
--- a/lib/asana/resources/user.rb
+++ b/lib/asana/resources/user.rb
@@ -14,6 +14,8 @@ module Asana
 
       attr_reader :id
 
+      attr_reader :gid
+
       attr_reader :name
 
       attr_reader :email


### PR DESCRIPTION
Regarding https://asana.com/developers/news/string-ids I am updating my own repo to use the string `gid`s.

In one of our specs were are creating a `User` resource. I would like to pass in a `gid` to the User resource and the read from it.  Currently this is failing because there is not `att_reader` for `gid` on the User.