### PR TITLE
Create task attachments directly from IOs

### DIFF
--- a/lib/asana/resource_includes/attachment_uploading.rb
+++ b/lib/asana/resource_includes/attachment_uploading.rb
@@ -5,8 +5,9 @@ module Asana
     module AttachmentUploading
       # Uploads a new attachment to the resource.
       #
-      # filename - [String] the absolute path of the file to upload.
+      # filename - [String] the absolute path of the file to upload OR the desired filename when using +io+
       # mime     - [String] the MIME type of the file
+      # io       - [IO] an object which returns the file's content on +#read+, e.g. a +::StringIO+
       # options  - [Hash] the request I/O options
       # data     - [Hash] extra attributes to post
       #
@@ -14,16 +15,22 @@ module Asana
       # rubocop:disable Metrics/MethodLength
       def attach(filename: required('filename'),
                  mime: required('mime'),
-                 options: {}, **data)
-        path = File.expand_path(filename)
-        unless File.exist?(path)
-          raise ArgumentError, "file #{filename} doesn't exist"
-        end
-        upload = Faraday::UploadIO.new(path, mime)
+                 io: nil, options: {}, **data)
+
+        upload = if io.nil?
+                   path = File.expand_path(filename)
+                   raise ArgumentError, "file #{filename} doesn't exist" unless File.exist?(path)
+
+                   Faraday::FilePart.new(path, mime)
+                 else
+                   Faraday::FilePart.new(io, mime, filename)
+                 end
+
         response = client.post("/#{self.class.plural_name}/#{gid}/attachments",
                                body: data,
                                upload: upload,
                                options: options)
+
         Attachment.new(parse(response).first, client: client)
       end
       # rubocop:enable Metrics/MethodLength

--- a/spec/asana/resources/attachment_uploading_spec.rb
+++ b/spec/asana/resources/attachment_uploading_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'support/stub_api'
 require 'support/resources_helper'
 
@@ -26,17 +28,42 @@ RSpec.describe Asana::Resources::AttachmentUploading do
   end
 
   describe '#attach' do
-    it 'uploads an attachment to a unicorn' do
-      arg_matcher = ->(body) { body.is_a?(Faraday::CompositeReadIO) }
+    let(:arg_matcher) { ->(body) { body.is_a?(Faraday::CompositeReadIO) } }
+    let(:unicorn) { unicorn_class.new({ gid: '1' }, client: client) }
+
+    before do
       api.on(:post, '/unicorns/1/attachments', arg_matcher) do |response|
-        response.body = { data: { gid: "10" } }
+        response.body = { data: { gid: '10' } }
       end
-      unicorn = unicorn_class.new({ gid: "1" }, client: client)
-      attachment = unicorn.attach(filename: __FILE__,
-                                  mime: 'image/jpg',
-                                  name: 'file')
-      expect(attachment).to be_a(Asana::Resources::Attachment)
-      expect(attachment.gid).to eq("10")
+    end
+
+    context 'with a file from the file system' do
+      it 'uploads an attachment to a unicorn' do
+        attachment = unicorn.attach(filename: __FILE__,
+                                    mime: 'image/jpg')
+
+        expect(attachment).to be_a(Asana::Resources::Attachment)
+        expect(attachment.gid).to eq('10')
+      end
+    end
+
+    context 'with an IO' do
+      let(:io) do
+        ::StringIO.new(<<~CSV)
+          Employee;Salary
+          "Bill Lumbergh";70000
+          "Peter Gibbons";40000
+        CSV
+      end
+
+      it 'uploads an attachment to a unicorn' do
+        attachment = unicorn.attach(io: io,
+                                    mime: 'text/csv',
+                                    filename: 'salaries.csv')
+
+        expect(attachment).to be_a(Asana::Resources::Attachment)
+        expect(attachment.gid).to eq('10')
+      end
     end
   end
 end


### PR DESCRIPTION
We extend the `AttachmentUploading#attach` method to also accept IOs.

This comes in handy when PDFs, CSV tables, ZIP files, etc.
are generated in memory and shall be attached to an Asana task
directly without writing to disk.

Writing to disk not only makes the process slower and potentially
clutters up the disk. Some users may have special data protection
concerns where processing "data in flight" is acceptable
but writing it to disk (i.e. "data at rest") is subject to
higher compliance requirements.