### PR TITLE
Make gem Ruby v3.0 compliant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
 - 2.4.3
 - 2.5.0
 - 2.7.1
+- 3.0.0
 deploy:
   provider: rubygems
   api_key:

--- a/asana.gemspec
+++ b/asana.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '> 2.0'
 
   spec.add_dependency "oauth2", "~> 1.4"
   spec.add_dependency "faraday", "~> 1.0"

--- a/spec/asana/resources/tag_spec.rb
+++ b/spec/asana/resources/tag_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Asana::Resources::Tag do
   include ResourcesHelper
 
   it 'contains backwards compatable method' do
-    tag = Asana::Resources::Tag.new({:gid => 15}, {:client => client})
+    tag = Asana::Resources::Tag.new({:gid => 15}, **{:client => client})
 
     api.on(:get, "/tags/#{tag.gid}/tasks") do |response|
       response.body = { data: [{foo: "bar"}] }

--- a/spec/asana/resources/task_spec.rb
+++ b/spec/asana/resources/task_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe Asana::Resources::Task do
       checks = checks + 1
     end
 
-    client.tasks.find_by_project({:project => gid})
-    client.tasks.find_by_project({:projectId => gid})
-    client.tasks.find_by_project({:project => nil, :projectId => gid})
-    client.tasks.find_by_project({:project => gid, :projectId => nil})
+    client.tasks.find_by_project(**{:project => gid})
+    client.tasks.find_by_project(**{:projectId => gid})
+    client.tasks.find_by_project(**{:project => nil, :projectId => gid})
+    client.tasks.find_by_project(**{:project => gid, :projectId => nil})
 
     expect(checks == 4)
   end


### PR DESCRIPTION
This pull request does a number of things:

1. Fix the `kwargs` calls to work properly with Ruby v3.0. You now have to be explicit about what is an argument and what are keyword arguments via the `**` operator.
2. Add Ruby v3.0.0 to Travis CI.
3. Loosen Ruby dependency version.