### PR TITLE
Remove Faraday connection authorization warnings

### DIFF
--- a/lib/asana/authentication/oauth2/bearer_token_authentication.rb
+++ b/lib/asana/authentication/oauth2/bearer_token_authentication.rb
@@ -24,7 +24,7 @@ module Asana
         #
         # Returns nothing.
         def configure(connection)
-          connection.authorization :Bearer, @token
+          connection.request :authorization, :Bearer, @token
           connection.request :oauth2, token_type: 'bearer'
         end
       end


### PR DESCRIPTION
Based on my read of https://lostisland.github.io/faraday/middleware/authentication, this should work fine in Faraday 1 and 2

Close #116 