### PR TITLE
Fix Travis CI failed builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: ruby
 rvm:
-- 2.3.6
-- 2.4.3
 - 2.5.0
 - 2.7.1
 - 3.0.0
+before_install:
+  - if [ "${TRAVIS_RUBY_VERSION}" != "3.0.0" ]; then gem update --system 3.2.3; fi
+  - if [ "${TRAVIS_RUBY_VERSION}" != "3.0.0" ]; then gem install bundler -v '>= 2.3.13'; fi
 deploy:
   provider: rubygems
   api_key:


### PR DESCRIPTION
- Remove builds for versions we don't support anymore
- Update RubyGems
- Install same bundler version that created lock file