### PR TITLE
Modularize global required method

### DIFF
--- a/lib/asana.rb
+++ b/lib/asana.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'asana/ruby2_0_0_compatibility'
+require 'asana/compatibility_helper'
 require 'asana/authentication'
 require 'asana/resources'
 require 'asana/client'

--- a/lib/asana/authentication/oauth2.rb
+++ b/lib/asana/authentication/oauth2.rb
@@ -28,8 +28,8 @@ module Asana
       #
       # Note: This function reads from STDIN and writes to STDOUT. It is meant
       # to be used only within the context of a CLI application.
-      def offline_flow(client_id: required('client_id'),
-                       client_secret: required('client_secret'))
+      def offline_flow(client_id: CompatibilityHelper.required('client_id'),
+                       client_secret: CompatibilityHelper.required('client_secret'))
         client = Client.new(client_id: client_id,
                             client_secret: client_secret,
                             redirect_uri: 'urn:ietf:wg:oauth:2.0:oob')

--- a/lib/asana/authentication/oauth2/access_token_authentication.rb
+++ b/lib/asana/authentication/oauth2/access_token_authentication.rb
@@ -20,9 +20,9 @@ module Asana
         # Returns an [AccessTokenAuthentication] instance with a refreshed
         # access token.
         def self.from_refresh_token(refresh_token,
-                                    client_id: required('client_id'),
-                                    client_secret: required('client_secret'),
-                                    redirect_uri: required('redirect_uri'))
+                                    client_id: CompatibilityHelper.required('client_id'),
+                                    client_secret: CompatibilityHelper.required('client_secret'),
+                                    redirect_uri: CompatibilityHelper.required('redirect_uri'))
           client = Client.new(client_id: client_id,
                               client_secret: client_secret,
                               redirect_uri: redirect_uri)

--- a/lib/asana/authentication/oauth2/client.rb
+++ b/lib/asana/authentication/oauth2/client.rb
@@ -17,9 +17,9 @@ module Asana
         #                 application
         # redirect_uri  - [String] a redirect uri from the registered
         #                 application
-        def initialize(client_id: required('client_id'),
-                       client_secret: required('client_secret'),
-                       redirect_uri: required('redirect_uri'))
+        def initialize(client_id: CompatibilityHelper.required('client_id'),
+                       client_secret: CompatibilityHelper.required('client_secret'),
+                       redirect_uri: CompatibilityHelper.required('redirect_uri'))
           @client = ::OAuth2::Client.new(client_id, client_secret,
                                          site: 'https://app.asana.com',
                                          authorize_url: '/-/oauth_authorize',

--- a/lib/asana/client.rb
+++ b/lib/asana/client.rb
@@ -56,7 +56,7 @@ module Asana
     # Internal: Proxies Resource classes to implement a fluent API on the Client
     # instances.
     class ResourceProxy
-      def initialize(client: required('client'), resource: required('resource'))
+      def initialize(client: CompatibilityHelper.required('client'), resource: CompatibilityHelper.required('resource'))
         @client   = client
         @resource = resource
       end

--- a/lib/asana/compatibility_helper.rb
+++ b/lib/asana/compatibility_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Asana
+  module CompatibilityHelper
+    def required(name)
+      raise(ArgumentError, "#{name} is a required keyword argument")
+    end
+
+    extend self
+  end
+end

--- a/lib/asana/http_client.rb
+++ b/lib/asana/http_client.rb
@@ -23,7 +23,7 @@ module Asana
     # user_agent     - [String] The user agent. Defaults to "ruby-asana vX.Y.Z".
     # config         - [Proc] An optional block that yields the Faraday builder
     #                  object for customization.
-    def initialize(authentication: required('authentication'),
+    def initialize(authentication: CompatibilityHelper.required('authentication'),
                    adapter: nil,
                    user_agent: nil,
                    debug_mode: false,

--- a/lib/asana/resource_includes/collection.rb
+++ b/lib/asana/resource_includes/collection.rb
@@ -21,7 +21,7 @@ module Asana
       # client            - [Asana::Client] the client to perform requests.
       def initialize((elements, extra),
                      type: Resource,
-                     client: required('client'))
+                     client: CompatibilityHelper.required('client'))
         @elements       = elements.map { |elem| type.new(elem, client: client) }
         @type           = type
         @next_page_data = extra['next_page']

--- a/lib/asana/resource_includes/events.rb
+++ b/lib/asana/resource_includes/events.rb
@@ -34,8 +34,8 @@ module Asana
       # client   - [Asana::Client] a client to perform the requests.
       # wait     - [Integer] the number of seconds to wait between each poll.
       # options  - [Hash] the request I/O options
-      def initialize(resource: required('resource'),
-                     client: required('client'),
+      def initialize(resource: CompatibilityHelper.required('resource'),
+                     client: CompatibilityHelper.required('client'),
                      wait: 1, options: {})
         @resource  = resource
         @client    = client

--- a/lib/asana/resource_includes/resource.rb
+++ b/lib/asana/resource_includes/resource.rb
@@ -2,6 +2,7 @@
 
 require_relative 'registry'
 require_relative 'response_helper'
+require_relative '../compatibility_helper'
 
 module Asana
   module Resources
@@ -10,6 +11,8 @@ module Asana
     class Resource
       include ResponseHelper
       extend ResponseHelper
+      include CompatibilityHelper
+      extend CompatibilityHelper
 
       def initialize(data, client: required('client'))
         @_client = client

--- a/lib/asana/ruby2_0_0_compatibility.rb
+++ b/lib/asana/ruby2_0_0_compatibility.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-def required(name)
-  raise(ArgumentError, "#{name} is a required keyword argument")
-end

--- a/spec/asana/authentication/oauth2/access_token_authentication_spec.rb
+++ b/spec/asana/authentication/oauth2/access_token_authentication_spec.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe Asana::Authentication::OAuth2::AccessTokenAuthentication do
+  describe '#from_refresh_token' do
+    let(:token) do
+      instance_double(OAuth2::AccessToken, expired?: false, token: 'TOKEN')
+    end
+
+    it 'raises an ArgumentError when required fields are missing' do
+      expect do
+        described_class.from_refresh_token(token)
+      end.to raise_error(ArgumentError)
+    end
+  end
+
   describe described_class do
     let(:auth) { described_class.new(token) }
 

--- a/spec/asana/authentication/oauth2/client_spec.rb
+++ b/spec/asana/authentication/oauth2/client_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Asana::Authentication::OAuth2::Client do
                         redirect_uri: 'http://redirect_uri.com')
   end
 
+  describe '#initialize' do
+    it 'raises an ArgumentError when required fields are missing' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+  end
+
   describe '#authorize_url' do
     it 'returns the OAuth2 authorize url' do
       expect(client.authorize_url)

--- a/spec/asana/http_client_spec.rb
+++ b/spec/asana/http_client_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Asana::HttpClient do
     described_class.new(authentication: auth, adapter: api.to_proc)
   end
 
+  describe '#initialize' do
+    it "raises an ArgumentError when required fields are missing" do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+  end
+  
   describe '#get' do
     it 'performs a GET request against the Asana API' do
       api.on(:get, '/users/me') do |response|

--- a/spec/asana/resources/attachment_uploading_spec.rb
+++ b/spec/asana/resources/attachment_uploading_spec.rb
@@ -65,5 +65,11 @@ RSpec.describe Asana::Resources::AttachmentUploading do
         expect(attachment.gid).to eq('10')
       end
     end
+
+    context 'without filename or mime' do
+      it 'raises an error' do
+        expect { unicorn.attach }.to raise_error(ArgumentError)
+      end
+    end
   end
 end

--- a/spec/asana/resources/collection_spec.rb
+++ b/spec/asana/resources/collection_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe Asana::Resources::Collection do
 
   include ResourcesHelper
 
+  describe '#initialize' do
+    context 'no client provided' do
+      it 'raises an ArgumentError' do
+         expect do
+          described_class.new([unicorns.take(5), {}], type: unicorn_class)
+         end.to raise_error(ArgumentError)
+      end
+    end
+  end
+
   describe '#each' do
     context 'if there is more than one page' do
       it 'transparently iterates over all of them' do

--- a/spec/asana/resources/events_spec.rb
+++ b/spec/asana/resources/events_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe Asana::Resources::Events do
 
   include ResourcesHelper
 
+  describe '#initialize' do
+    it 'raises an ArgumentError when required fields are missing' do
+      expect do
+        described_class.new(wait: 0).take(3)
+      end.to raise_error(ArgumentError)
+    end
+  end
+
   it 'is an infinite collection of events on a resource' do
     api.on(:get, '/events', resource: '1') do |response|
       response.body = { sync: 'firstsynctoken',


### PR DESCRIPTION
This PR fixes #45 and builds off of [mful](https://github.com/mful)'s [previous PR for this issue](https://github.com/Asana/ruby-asana/pull/47).

It should be noted that #45 specifically mentions a compatibility issue with [FactoryBot](https://github.com/thoughtbot/factory_bot), but the issue is much broader than that. This gem currently introduces a `required` method globally in the projects that use it, which breaks _any_ method named `required` in those projects.

This particular solution:

- Moves the `required` method to a new `Asana::CompatibilityHelper` module that can be used safely throughout this codebase without making it a global method in any project it's used in.
- Does not modify generated code--to the best of my knowledge, let me know if I've missed something!