### PR TITLE
remove missing omniauth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ get '/auth/:name/callback' do
 end
 ```
 
-See `examples/omniauth_integration.rb` for a working example of this.
-
 ##### Using an OAuth2 offline authentication flow (for CLI applications)
 
 If your application can't receive HTTP requests and thus you can't use


### PR DESCRIPTION
### Description

This pull request removes a line of code that references a non-existent file `examples/omniauth_integration.rb`. The removal is necessary to prevent errors and maintain code integrity.

### Changes

- Removed the line referencing `examples/omniauth_integration.rb` from the codebase.

### Reason

The file `examples/omniauth_integration.rb` does not exist in the repository, which could lead to potential errors or confusion.
